### PR TITLE
added stagger example, error handling for submissionresult

### DIFF
--- a/examples/staggered_loop.py
+++ b/examples/staggered_loop.py
@@ -1,0 +1,15 @@
+"""
+Convert human reviewed submissions from a workflow to a 'labeled data'format and writes it to CSV.
+"""
+from solutions_toolkit.staggered_loop import StaggeredLoop
+from solutions_toolkit import create_client
+
+
+client = create_client("app.indico.io", "./indico_api_token.txt")
+stagger = StaggeredLoop(client)
+# workflow_id is required, but optionally specify submission ids to include and 
+# the specific model name if more than 1 in workflow
+stagger.get_reviewed_prediction_data(
+    workflow_id=412, submission_ids=[123, 415, 987], model_name="model_v1"
+)
+stagger.write_csv("./data_to_add_to_model.csv")

--- a/solutions_toolkit/staggered_loop/staggered_loop.py
+++ b/solutions_toolkit/staggered_loop/staggered_loop.py
@@ -72,7 +72,7 @@ class StaggeredLoop(Workflow):
     def _reformat_predictions(self, predictions: Predictions) -> List[dict]:
         predictions.remove_human_added_predictions()
         predictions.remove_keys(self._keys_to_remove)
-        return predictions.tolist()
+        return predictions.to_list()
 
     def _get_nested_predictions(self, wf_result: WorkflowResult) -> Predictions:
         if self.model_name != "":

--- a/solutions_toolkit/types/predictions.py
+++ b/solutions_toolkit/types/predictions.py
@@ -11,7 +11,6 @@ class Predictions:
     """
     Functionality for common extraction prediction use cases
     """
-
     def __init__(self, predictions: List[dict]):
         self._preds = predictions
 
@@ -71,7 +70,7 @@ class Predictions:
             i for i in self._preds if not self._is_manually_added_prediction(i)
         ]
 
-    def tolist(self):
+    def to_list(self):
         return self._preds
 
     def _is_manually_added_prediction(self, prediction: dict) -> bool:

--- a/tests/auto_review/test_auto_review.py
+++ b/tests/auto_review/test_auto_review.py
@@ -50,7 +50,7 @@ def test_submit_submission_review(
 ):
     wflow = Workflow(indico_client)
     job = wflow.submit_submission_review(
-        id_pending_scripted, {model_name: wflow_submission_result.predictions.tolist()}
+        id_pending_scripted, {model_name: wflow_submission_result.predictions.to_list()}
     )
     assert isinstance(job, Job)
 
@@ -62,7 +62,7 @@ def test_submit_auto_review(indico_client, id_pending_scripted, model_name):
     # Submit to workflow and get predictions
     wflow = Workflow(indico_client)
     result = wflow.get_submission_results_from_ids([id_pending_scripted])[0]
-    predictions = result.predictions.tolist()
+    predictions = result.predictions.to_list()
     # Review the submission
     field_config = [
         {"function": "accept_by_confidence", "kwargs": {"conf_threshold": 0.99}},
@@ -82,7 +82,7 @@ def test_submit_auto_review(indico_client, id_pending_scripted, model_name):
         id_pending_scripted, {model_name: reviewer.updated_predictions}
     )
     result = wflow.get_submission_results_from_ids([id_pending_scripted])[0]
-    for pred in result.post_review_predictions.tolist():
+    for pred in result.post_review_predictions.to_list():
         label = pred["label"]
         if (
             label in ["Liability Amount", "Date of Appointment"]

--- a/tests/indico_wrapper/test_reviewer.py
+++ b/tests/indico_wrapper/test_reviewer.py
@@ -22,7 +22,7 @@ def get_change_formatted_predictions(workflow_result):
     """
     Helper function for get change format for accepted predictions in test_accept_review
     """
-    return {workflow_result.model_name: workflow_result.predictions.tolist()}
+    return {workflow_result.model_name: workflow_result.predictions.to_list()}
 
 
 def test_accept_review(submissions_awaiting_review, indico_client, workflow_id):

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -3,7 +3,6 @@ from solutions_toolkit.indico_wrapper import Workflow
 from tests.conftest import MODEL_NAME
 
 
-
 def test_workflow_submit_and_get_rows(indico_client, workflow_id, pdf_filepath):
     """
     Submit a document to workflow, get results and ocr object, then association line items
@@ -16,7 +15,8 @@ def test_workflow_submit_and_get_rows(indico_client, workflow_id, pdf_filepath):
     sub_result = wflow.get_submission_results_from_ids([sub_ids[0]])[0]
     # TODO: update Association to work with Predictions object natively
     litems = Association(
-        ["Previous Position", "Previous Organization"], predictions=sub_result.predictions.tolist()
+        ["Previous Position", "Previous Organization"],
+        predictions=sub_result.predictions.to_list(),
     )
     ondoc_ocr = wflow.get_ondoc_ocr_from_etl_url(sub_result.etl_url)
     litems.get_bounding_boxes(ocr_tokens=ondoc_ocr.token_objects)

--- a/tests/types/test_predictions.py
+++ b/tests/types/test_predictions.py
@@ -6,7 +6,7 @@ from solutions_toolkit.types import Predictions
 
 def test_init(static_preds):
     predictions = Predictions(static_preds)
-    assert predictions.tolist() == static_preds
+    assert predictions.to_list() == static_preds
     assert isinstance(predictions["Name"], list)
     assert isinstance(predictions["Name"][0], dict)
     assert isinstance(predictions["Name"][0]["label"], str)
@@ -15,7 +15,7 @@ def test_init(static_preds):
 def test_remove_by_confidence(predictions_obj):
     predictions_obj.remove_by_confidence(confidence=0.95, labels=["Name", "Department"])
     predictions_obj.remove_by_confidence(confidence=0.9)
-    for pred in predictions_obj.tolist():
+    for pred in predictions_obj.to_list():
         label = pred["label"]
         if label in ["Name", "Department"]:
             assert pred["confidence"][label] > 0.95


### PR DESCRIPTION
Adding error handling for IndicoRequestError for submissionresult (thrown if deleted for example). 
Switched API from tolist to to_list for Predictions (aligns with 'to_csv')
Adding example for StaggeredLooop