### PR TITLE
accounting for alternate classification formatting

### DIFF
--- a/indico_toolkit/types/__init__.py
+++ b/indico_toolkit/types/__init__.py
@@ -2,4 +2,4 @@ from .workflow_object import WorkflowResult
 from .predictions import Predictions
 from .teach_task import TeachTask
 from .extractions import Extractions
-from .classification import Classification
+from .classification import Classification, ClassificationMGP

--- a/indico_toolkit/types/classification.py
+++ b/indico_toolkit/types/classification.py
@@ -1,5 +1,6 @@
 from typing import Dict
 import pandas as pd
+from operator import itemgetter
 
 from indico_toolkit.pipelines import FileProcessing
 
@@ -8,6 +9,7 @@ class Classification:
     """
     Functionality for classification predictions
     """
+
     def __init__(self, prediction: dict):
         self._pred = prediction
 
@@ -18,7 +20,7 @@ class Classification:
     @property
     def labels(self) -> list:
         return list(self.confidence_scores.keys())
-    
+
     @property
     def confidence(self) -> float:
         return self.confidence_scores[self.label]
@@ -28,12 +30,14 @@ class Classification:
         Overwite confidence dictionary to just max confidence float
         """
         self._pred["confidence"] = self._pred["confidence"][self.label]
-    
+
     @property
     def confidence_scores(self) -> Dict[str, float]:
         return self._pred["confidence"]
 
-    def to_csv(self, save_path, filename: str = "", append_if_exists: bool = True) -> None:
+    def to_csv(
+        self, save_path, filename: str = "", append_if_exists: bool = True
+    ) -> None:
         results = {filename: self._pred}
         df = pd.DataFrame(results).transpose()
         df["filename"] = filename
@@ -41,3 +45,35 @@ class Classification:
             df.to_csv(save_path, mode="a", header=False, index=False)
         else:
             df.to_csv(save_path, index=False)
+
+
+class ClassificationMGP(Classification):
+    """
+    Classification wrapper to account for
+    ModelGroupPredict returning a varied json output compared with Workflow
+
+    EXAMPLE:::
+        {'Type A': 0.99, 'Type B': 0.01}
+    """
+
+    @property
+    def label(self) -> str:
+        return max(self._pred.items(), key=itemgetter(1))[0]
+
+    @property
+    def labels(self) -> list:
+        return list(self._pred.keys())
+
+    @property
+    def confidence(self) -> float:
+        return self._pred[self.label]
+
+    def set_confidence_key_to_max_value(self):
+        """
+        Overwite confidence dictionary to just max confidence float
+        """
+        self._pred["confidence"] = self.confidence
+
+    @property
+    def confidence_scores(self) -> Dict[str, float]:
+        return self._pred

--- a/indico_toolkit/types/predictions.py
+++ b/indico_toolkit/types/predictions.py
@@ -1,8 +1,8 @@
 from typing import List, Dict, Set
 
-import indico_toolkit.types
 from indico_toolkit.errors import ToolkitInputError
-
+from .extractions import Extractions
+from .classification import Classification, ClassificationMGP
 
 class Predictions:
     """
@@ -15,8 +15,11 @@ class Predictions:
         Extractions object or Classification object depending on predictions type
         """
         if type(predictions) == list:
-            return indico_toolkit.types.Extractions(predictions)
+            return Extractions(predictions)
         elif type(predictions) == dict:
-            return indico_toolkit.types.Classification(predictions)
+            if "label" in predictions:
+                return Classification(predictions)
+            else:
+                return ClassificationMGP(predictions)
         else:
             raise ToolkitInputError(f"Unable to process predictions with type {type(predictions)}. Predictions: {predictions}")

--- a/tests/types/test_classifications.py
+++ b/tests/types/test_classifications.py
@@ -2,12 +2,13 @@ from copy import deepcopy
 import tempfile
 import pandas as pd
 
-from indico_toolkit.types import Classification
+from indico_toolkit.types import Classification, ClassificationMGP
 
 
 def test_init(static_class_preds):
     classification = Classification(static_class_preds)
     assert classification._pred == static_class_preds
+
 
 def test_properties(classification_obj):
     assert classification_obj.label == "1"
@@ -15,10 +16,12 @@ def test_properties(classification_obj):
     assert len(classification_obj.confidence_scores.keys()) == 4
     assert classification_obj.confidence == 0.31
 
+
 def test_set_confidence_key_to_max_value(classification_obj):
     max_conf = max(classification_obj.confidence_scores.values())
     classification_obj.set_confidence_key_to_max_value()
-    assert  classification_obj.confidence_scores == max_conf
+    assert classification_obj.confidence_scores == max_conf
+
 
 def test_to_csv(classification_obj):
     duplicated_obj = deepcopy(classification_obj)
@@ -31,3 +34,11 @@ def test_to_csv(classification_obj):
         duplicated_obj.to_csv(filepath, append_if_exists=True)
         df = pd.read_csv(filepath)
         assert df.shape == (2, 3)
+
+
+def test_classification_MGP():
+    obj = ClassificationMGP({"class A": 0.6, "class B": 0.4})
+    assert obj.label == "class A"
+    assert obj.confidence == 0.6
+    assert obj.confidence_scores == {"class A": 0.6, "class B": 0.4}
+    assert obj.labels == ["class A", "class B"]

--- a/tests/types/test_predictions.py
+++ b/tests/types/test_predictions.py
@@ -2,7 +2,12 @@ from _pytest.python import Class
 from tests.types.conftest import extractions_obj
 import pytest
 
-from indico_toolkit.types import Predictions, Extractions, Classification
+from indico_toolkit.types import (
+    Predictions,
+    Extractions,
+    Classification,
+    ClassificationMGP,
+)
 from indico_toolkit.errors import ToolkitInputError
 
 
@@ -21,3 +26,9 @@ def test_get_obj_classification(static_class_preds):
     classification_obj = Predictions.get_obj(static_class_preds)
     assert isinstance(classification_obj, Classification)
     assert classification_obj._pred == static_class_preds
+
+
+def test_get_obj_classification_mgp():
+    classification_obj = Predictions.get_obj({"class A": 0.6, "class B": 0.4})
+    assert isinstance(classification_obj, ClassificationMGP)
+


### PR DESCRIPTION
Classification results vary based on whether it uses modelgrouppredict or workflow, specifically: 

model group predict
{'Bank Notice': 0.9999970092733313, 'Funding Memo': 2.9907266686340967e-06}

workflow
{'confidence': {'Bank Notice': 0.9999970092733313,
  'Funding Memo': 2.9907266686340967e-06},
 'label': 'Bank Notice'}