### PR TITLE
keep removed predictions

### DIFF
--- a/tests/types/test_extractions.py
+++ b/tests/types/test_extractions.py
@@ -100,9 +100,11 @@ def test_remove_all_by_label(test_extraction_preds):
     extract = Extractions(test_extraction_preds)
     extract._remove_all_by_label("Paydown Amount")
     assert len([i for i in extract.to_list() if i["label"] == "Paydown Amount"]) == 0
+    assert len(extract.removed_predictions) == 3
 
 
 def test_remove_except_max_drop_and_ignore(test_extraction_preds):
     extract = Extractions(test_extraction_preds)
     extract.remove_except_max_confidence(labels=["Paydown Amount"])
     assert len(extract) == 3
+    assert len(extract.removed_predictions) == 2


### PR DESCRIPTION
For some use cases, it would be useful to keep the "removed predictions" from the Extractions class so that you can potentially log these for debugging purposes, i.e. "oh I didn't get the name right because it was the 2nd highest confidence"