### PR TITLE
fix: relax indico client version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ home-page = "https://github.com/IndicoDataSolutions/Indico-Solutions-Toolkit"
 classifiers = [ "License :: OSI Approved :: MIT License",]
 description-file = "README.md"
 requires = [
-    "indico-client==5.1.3",
+    "indico-client>=5.1.4",
     "plotly==5.2.1",
     "tqdm==4.50.0",
     "faker==13.3.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-indico-client==5.1.3
+indico-client>=5.1.4
 python-dateutil==2.8.1
 PyMuPDF==1.19.6
 pytz==2021.1

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name="indico-toolkit",
@@ -15,7 +15,7 @@ setup(
         "coverage>=5.5",
     ],
     install_requires=[
-        "indico-client==5.1.3",
+        "indico-client>=5.1.4",
         "plotly==5.2.1",
         "tqdm==4.50.0",
         "faker==13.3.3",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="indico-toolkit",
-    version="2.0.1",
+    version="2.0.2",
     packages=find_packages(exclude=["tests"]),
     description="""Tools to assist with Indico IPA development""",
     license="MIT License (See LICENSE)",


### PR DESCRIPTION
Changes the minimum version for `indico-client` to avoid dependency conflicts with `jetsteam` and `indicore`.

not sure what the release and testing process is for this