### PR TITLE
resolve highlighter bug

### DIFF
--- a/indico_toolkit/highlighter/highlighter.py
+++ b/indico_toolkit/highlighter/highlighter.py
@@ -292,6 +292,7 @@ class Highlighter(ExtractedTokens):
             color (str, optional): label color. Defaults to "red".
         """
         captured_preds = set()
+        page.clean_contents()
         for token in tokens:
             if token["prediction_index"] not in captured_preds:
                 text_height = int(


### PR DESCRIPTION
-- Resolve bug in highlighter annotation where labels added would be upside down and reversed.
Relevant thread: https://github.com/pymupdf/PyMuPDF/issues/337

Before:
<img width="1134" alt="Screen Shot 2022-08-15 at 8 04 58 AM" src="https://user-images.githubusercontent.com/99516527/184661160-977b3a29-b845-4822-8c6b-e0fd856f0bca.png">

After:
<img width="1137" alt="Screen Shot 2022-08-15 at 8 04 21 AM" src="https://user-images.githubusercontent.com/99516527/184661220-d0d8ea07-0b91-469c-803a-a2adb0c0d3ee.png">


