### PR TITLE
Result File Dataclasses: Improve Extraction API

### DIFF
--- a/examples/results_dataclasses.py
+++ b/examples/results_dataclasses.py
@@ -117,6 +117,7 @@ prediction.extras  # Other attributes from the result file prediction dict that 
 # Extraction Dataclass (Subclass of Prediction)
 extraction = predictions.extractions[0]
 extraction.text
+extraction.page
 extraction.accepted
 extraction.rejected
 

--- a/examples/results_dataclasses.py
+++ b/examples/results_dataclasses.py
@@ -1,6 +1,7 @@
 """
 Overview of dataclasses and functionality available in the results module.
 """
+
 from operator import attrgetter
 from pathlib import Path
 
@@ -116,10 +117,6 @@ prediction.extras  # Other attributes from the result file prediction dict that 
 # Extraction Dataclass (Subclass of Prediction)
 extraction = predictions.extractions[0]
 extraction.text
-extraction.start
-extraction.end
-extraction.page
-extraction.groups  # Any linked label groups this prediction is a part of
 extraction.accepted
 extraction.rejected
 
@@ -127,3 +124,36 @@ extraction.accept()  # Mark this extraction as accepted for auto review
 extraction.reject()  # Mark this extraction as rejected for auto review
 extraction.unaccept()  # Mark this extraction as not accepted for auto review
 extraction.unreject()  # Mark this extraction as not rejected for auto review
+
+
+# DocumentExtraction Dataclass (Subclass of Extraction)
+document_extraction = predictions.document_extractions[0]
+document_extraction.text
+document_extraction.page
+document_extraction.start
+document_extraction.end
+document_extraction.groups  # Any linked label groups this prediction is a part of
+document_extraction.accepted
+document_extraction.rejected
+
+document_extraction.accept()  # Mark this extraction as accepted for auto review
+document_extraction.reject()  # Mark this extraction as rejected for auto review
+document_extraction.unaccept()  # Mark this extraction as not accepted for auto review
+document_extraction.unreject()  # Mark this extraction as not rejected for auto review
+
+
+# FormExtraction Dataclass (Subclass of Extraction)
+form_extraction = predictions.form_extractions[0]
+form_extraction.text
+form_extraction.page
+form_extraction.top
+form_extraction.left
+form_extraction.right
+form_extraction.bottom
+form_extraction.accepted
+form_extraction.rejected
+
+form_extraction.accept()  # Mark this extraction as accepted for auto review
+form_extraction.reject()  # Mark this extraction as rejected for auto review
+form_extraction.unaccept()  # Mark this extraction as not accepted for auto review
+form_extraction.unreject()  # Mark this extraction as not rejected for auto review

--- a/examples/results_to_csv.py
+++ b/examples/results_to_csv.py
@@ -1,6 +1,7 @@
 """
 Dump classifications and extractions from result files to a CSV file.
 """
+
 import csv
 from collections.abc import Iterable, Iterator
 from pathlib import Path
@@ -14,16 +15,16 @@ def final_predictions(result: results.Result) -> Iterator[dict[str, object]]:
     for prediction in result.final:
         if isinstance(prediction, results.Classification):
             yield {
-                "submission_id": result.id,
+                "submission_id": result.submission_id,
                 "document_id": prediction.document.id,
                 "model": prediction.model.name,
                 "field": "Classification",
                 "value": prediction.label,
                 "confidence": prediction.confidence,
             }
-        else:
+        elif isinstance(prediction, results.Extraction):
             yield {
-                "submission_id": result.id,
+                "submission_id": result.submission_id,
                 "document_id": prediction.document.id,
                 "model": prediction.model.name,
                 "field": prediction.label,
@@ -57,7 +58,9 @@ def convert_to_csv(
                 "value",
                 "confidence",
             ],
-        ).writerows(predictions_from_files(result_files))
+        ).writerows(
+            predictions_from_files(result_files),
+        )
 
 
 if __name__ == "__main__":

--- a/indico_toolkit/results/__init__.py
+++ b/indico_toolkit/results/__init__.py
@@ -6,8 +6,8 @@ from .errors import ResultError
 from .lists import PredictionList
 from .models import ModelGroup, TaskType
 from .predictions import (
-    AutoReviewable,
     Classification,
+    DocumentExtraction,
     Extraction,
     FormExtraction,
     FormExtractionType,
@@ -20,9 +20,9 @@ from .reviews import Review, ReviewType
 from .utils import get
 
 __all__ = (
-    "AutoReviewable",
     "Classification",
     "Document",
+    "DocumentExtraction",
     "Extraction",
     "FormExtraction",
     "FormExtractionType",

--- a/indico_toolkit/results/lists.py
+++ b/indico_toolkit/results/lists.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING, List, TypeVar, overload
 
 from .models import TaskType
 from .predictions import (
-    AutoReviewable,
     Classification,
+    DocumentExtraction,
     Extraction,
     FormExtraction,
     Prediction,
@@ -38,6 +38,10 @@ class PredictionList(List[PredictionType]):
     @property
     def classifications(self) -> "PredictionList[Classification]":
         return self.oftype(Classification)
+
+    @property
+    def document_extractions(self) -> "PredictionList[DocumentExtraction]":
+        return self.oftype(DocumentExtraction)
 
     @property
     def extractions(self) -> "PredictionList[Extraction]":
@@ -182,13 +186,13 @@ class PredictionList(List[PredictionType]):
 
         if accepted is not None:
             predicates.append(
-                lambda prediction: isinstance(prediction, AutoReviewable)
+                lambda prediction: isinstance(prediction, Extraction)
                 and prediction.accepted == accepted
             )
 
         if rejected is not None:
             predicates.append(
-                lambda prediction: isinstance(prediction, AutoReviewable)
+                lambda prediction: isinstance(prediction, Extraction)
                 and prediction.rejected == rejected
             )
 
@@ -210,28 +214,28 @@ class PredictionList(List[PredictionType]):
         """
         Mark predictions as accepted for auto-review.
         """
-        self.oftype(AutoReviewable).apply(AutoReviewable.accept)
+        self.oftype(Extraction).apply(Extraction.accept)
         return self
 
     def unaccept(self) -> "Self":
         """
         Mark predictions as not accepted for auto-review.
         """
-        self.oftype(AutoReviewable).apply(AutoReviewable.unaccept)
+        self.oftype(Extraction).apply(Extraction.unaccept)
         return self
 
     def reject(self) -> "Self":
         """
         Mark predictions as rejected for auto-review.
         """
-        self.oftype(AutoReviewable).apply(AutoReviewable.reject)
+        self.oftype(Extraction).apply(Extraction.reject)
         return self
 
     def unreject(self) -> "Self":
         """
         Mark predictions as not rejected for auto-review.
         """
-        self.oftype(AutoReviewable).apply(AutoReviewable.unreject)
+        self.oftype(Extraction).apply(Extraction.unreject)
         return self
 
     def to_changes(self, result: "Result") -> "Any":

--- a/indico_toolkit/results/lists.py
+++ b/indico_toolkit/results/lists.py
@@ -135,7 +135,7 @@ class PredictionList(List[PredictionType]):
         label_in: predictions with one of these labels,
         min_confidence: predictions with confidence >= this threshold,
         max_confidence: predictions with confidence <= this threshold,
-        accepted: extractions that have accepted,
+        accepted: extractions that have been accepted,
         rejected: extractions that have been rejected,
         checked: form extractions that are checked,
         signed: form extractions that are signed,
@@ -212,28 +212,28 @@ class PredictionList(List[PredictionType]):
 
     def accept(self) -> "Self":
         """
-        Mark predictions as accepted for auto-review.
+        Mark extractions as accepted for auto review.
         """
         self.oftype(Extraction).apply(Extraction.accept)
         return self
 
     def unaccept(self) -> "Self":
         """
-        Mark predictions as not accepted for auto-review.
+        Mark extractions as not accepted for auto review.
         """
         self.oftype(Extraction).apply(Extraction.unaccept)
         return self
 
     def reject(self) -> "Self":
         """
-        Mark predictions as rejected for auto-review.
+        Mark extractions as rejected for auto review.
         """
         self.oftype(Extraction).apply(Extraction.reject)
         return self
 
     def unreject(self) -> "Self":
         """
-        Mark predictions as not rejected for auto-review.
+        Mark extractions as not rejected for auto review.
         """
         self.oftype(Extraction).apply(Extraction.unreject)
         return self

--- a/indico_toolkit/results/models.py
+++ b/indico_toolkit/results/models.py
@@ -6,7 +6,7 @@ from .utils import get, has
 
 class TaskType(Enum):
     CLASSIFICATION = "classification"
-    EXTRACTION = "annotation"
+    DOCUMENT_EXTRACTION = "annotation"
     FORM_EXTRACTION = "form_extraction"
     UNBUNDLING = "classification_unbundling"
 
@@ -31,12 +31,12 @@ class ModelGroup:
             if has(prediction, str, "type"):
                 task_type = TaskType.FORM_EXTRACTION
             elif has(prediction, str, "text"):
-                task_type = TaskType.EXTRACTION
+                task_type = TaskType.DOCUMENT_EXTRACTION
             else:
                 task_type = TaskType.CLASSIFICATION
         else:
             # Likely an extraction model that produced no predictions.
-            task_type = TaskType.EXTRACTION
+            task_type = TaskType.DOCUMENT_EXTRACTION
 
         return ModelGroup(
             # v1 result files don't include model IDs.

--- a/indico_toolkit/results/normalization.py
+++ b/indico_toolkit/results/normalization.py
@@ -58,11 +58,11 @@ def normalize_v1_result(result: "Any") -> None:
                 prediction["right"] = 0
                 prediction["bottom"] = 0
 
-            # Prior to 6.11, some extractions lack a `normalized` section after review.
+            # Prior to 6.11, some Extractions lack a `normalized` section after review.
             if "text" in prediction and "normalized" not in prediction:
                 prediction["normalized"] = {"formatted": prediction["text"]}
 
-            # Document extractions that didn't go through a linked labels transformer
+            # Document Extractions that didn't go through a linked labels transformer
             # lack a `groupings` section.
             if (
                 "text" in prediction
@@ -123,12 +123,12 @@ def normalize_v3_result(result: "Any") -> None:
                     prediction["right"] = 0
                     prediction["bottom"] = 0
 
-                # Prior to 6.11, some extractions lack a `normalized` section after
+                # Prior to 6.11, some Extractions lack a `normalized` section after
                 # review.
                 if "text" in prediction and "normalized" not in prediction:
                     prediction["normalized"] = {"formatted": prediction["text"]}
 
-                # Document extractions that didn't go through a linked labels
+                # Document Extractions that didn't go through a linked labels
                 # transformer lack a `groupings` section.
                 if (
                     "text" in prediction

--- a/indico_toolkit/results/predictions/__init__.py
+++ b/indico_toolkit/results/predictions/__init__.py
@@ -1,8 +1,8 @@
 from typing import TYPE_CHECKING
 
 from ..models import TaskType
-from .autoreviewable import AutoReviewable
 from .classifications import Classification
+from .documentextractions import DocumentExtraction
 from .extractions import Extraction
 from .formextractions import FormExtraction, FormExtractionType
 from .groups import Group
@@ -16,8 +16,8 @@ if TYPE_CHECKING:
     from ..reviews import Review
 
 __all__ = (
-    "AutoReviewable",
     "Classification",
+    "DocumentExtraction",
     "Extraction",
     "FormExtraction",
     "FormExtractionType",
@@ -38,8 +38,8 @@ def from_v1_dict(
     """
     if model.task_type == TaskType.CLASSIFICATION:
         return Classification.from_v1_dict(document, model, review, prediction)
-    elif model.task_type == TaskType.EXTRACTION:
-        return Extraction.from_v1_dict(document, model, review, prediction)
+    elif model.task_type == TaskType.DOCUMENT_EXTRACTION:
+        return DocumentExtraction.from_v1_dict(document, model, review, prediction)
     elif model.task_type == TaskType.FORM_EXTRACTION:
         return FormExtraction.from_v1_dict(document, model, review, prediction)
     else:
@@ -57,8 +57,8 @@ def from_v3_dict(
     """
     if model.task_type == TaskType.CLASSIFICATION:
         return Classification.from_v3_dict(document, model, review, prediction)
-    elif model.task_type == TaskType.EXTRACTION:
-        return Extraction.from_v3_dict(document, model, review, prediction)
+    elif model.task_type == TaskType.DOCUMENT_EXTRACTION:
+        return DocumentExtraction.from_v3_dict(document, model, review, prediction)
     elif model.task_type == TaskType.FORM_EXTRACTION:
         return FormExtraction.from_v3_dict(document, model, review, prediction)
     elif model.task_type == TaskType.UNBUNDLING:

--- a/indico_toolkit/results/predictions/documentextractions.py
+++ b/indico_toolkit/results/predictions/documentextractions.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from ..reviews import Review
 from ..utils import get, has, omit
-from .autoreviewable import AutoReviewable
+from .extractions import Extraction
 from .groups import Group
 
 if TYPE_CHECKING:
@@ -14,8 +14,7 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class Extraction(AutoReviewable):
-    text: str
+class DocumentExtraction(Extraction):
     page: int
     start: int
     end: int
@@ -27,11 +26,11 @@ class Extraction(AutoReviewable):
         model: "ModelGroup",
         review: "Review | None",
         prediction: object,
-    ) -> "Extraction":
+    ) -> "DocumentExtraction":
         """
-        Create an `Extraction` from a v1 prediction dictionary.
+        Create an `DocumentExtraction` from a v1 prediction dictionary.
         """
-        return Extraction(
+        return DocumentExtraction(
             document=document,
             model=model,
             review=review,
@@ -67,11 +66,11 @@ class Extraction(AutoReviewable):
         model: "ModelGroup",
         review: "Review | None",
         prediction: object,
-    ) -> "Extraction":
+    ) -> "DocumentExtraction":
         """
-        Create an `Extraction` from a v3 prediction dictionary.
+        Create an `DocumentExtraction` from a v3 prediction dictionary.
         """
-        return Extraction(
+        return DocumentExtraction(
             document=document,
             model=model,
             review=review,

--- a/indico_toolkit/results/predictions/documentextractions.py
+++ b/indico_toolkit/results/predictions/documentextractions.py
@@ -28,7 +28,7 @@ class DocumentExtraction(Extraction):
         prediction: object,
     ) -> "DocumentExtraction":
         """
-        Create an `DocumentExtraction` from a v1 prediction dictionary.
+        Create n `DocumentExtraction` from a v1 prediction dictionary.
         """
         return DocumentExtraction(
             document=document,
@@ -68,7 +68,7 @@ class DocumentExtraction(Extraction):
         prediction: object,
     ) -> "DocumentExtraction":
         """
-        Create an `DocumentExtraction` from a v3 prediction dictionary.
+        Create a `DocumentExtraction` from a v3 prediction dictionary.
         """
         return DocumentExtraction(
             document=document,

--- a/indico_toolkit/results/predictions/documentextractions.py
+++ b/indico_toolkit/results/predictions/documentextractions.py
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
 
 @dataclass
 class DocumentExtraction(Extraction):
-    page: int
     start: int
     end: int
     groups: "set[Group]"

--- a/indico_toolkit/results/predictions/extractions.py
+++ b/indico_toolkit/results/predictions/extractions.py
@@ -8,6 +8,7 @@ class Extraction(Prediction):
     accepted: bool
     rejected: bool
     text: str
+    page: int
 
     def accept(self) -> None:
         self.accepted = True

--- a/indico_toolkit/results/predictions/extractions.py
+++ b/indico_toolkit/results/predictions/extractions.py
@@ -4,9 +4,10 @@ from .predictions import Prediction
 
 
 @dataclass
-class AutoReviewable(Prediction):
+class Extraction(Prediction):
     accepted: bool
     rejected: bool
+    text: str
 
     def accept(self) -> None:
         self.accepted = True

--- a/indico_toolkit/results/predictions/formextractions.py
+++ b/indico_toolkit/results/predictions/formextractions.py
@@ -25,7 +25,6 @@ class FormExtraction(Extraction):
     checked: bool
     signed: bool
 
-    page: int
     top: int
     left: int
     right: int

--- a/indico_toolkit/results/predictions/formextractions.py
+++ b/indico_toolkit/results/predictions/formextractions.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from ..reviews import Review
 from ..utils import get, has, omit
-from .autoreviewable import AutoReviewable
+from .extractions import Extraction
 
 if TYPE_CHECKING:
     from typing import Any
@@ -20,11 +20,10 @@ class FormExtractionType(Enum):
 
 
 @dataclass
-class FormExtraction(AutoReviewable):
+class FormExtraction(Extraction):
     type: FormExtractionType
     checked: bool
     signed: bool
-    text: str
 
     page: int
     top: int

--- a/tests/results/test_lists.py
+++ b/tests/results/test_lists.py
@@ -99,7 +99,7 @@ def predictions(
                 text="Doe",
                 start=357,
                 end=360,
-                page=0,
+                page=1,
                 groups=set(),
             ),
         ]
@@ -186,6 +186,20 @@ def test_where_confidence(predictions: "PredictionList[Prediction]") -> None:
     assert conf_70 in filtered
     assert conf_80 not in filtered
     assert conf_90 not in filtered
+
+
+def test_where_page(predictions: "PredictionList[Prediction]") -> None:
+    classification, first_name, last_name = predictions
+
+    filtered = predictions.where(page=0)
+    assert classification not in filtered
+    assert first_name in filtered
+    assert last_name not in filtered
+
+    filtered = predictions.where(page_in=(0, 1))
+    assert classification not in filtered
+    assert first_name in filtered
+    assert last_name in filtered
 
 
 def test_where_accepted(predictions: "PredictionList[Prediction]") -> None:

--- a/tests/results/test_lists.py
+++ b/tests/results/test_lists.py
@@ -3,15 +3,15 @@ from operator import attrgetter
 import pytest
 
 from indico_toolkit.results import (
+    Classification,
+    Document,
+    DocumentExtraction,
+    ModelGroup,
+    Prediction,
     PredictionList,
     Review,
     ReviewType,
-    ModelGroup,
     TaskType,
-    Document,
-    Extraction,
-    Prediction,
-    Classification,
 )
 
 
@@ -36,7 +36,7 @@ def classification_model() -> ModelGroup:
 @pytest.fixture
 def extraction_model() -> ModelGroup:
     return ModelGroup(
-        id=122, name="1040 Document Extraction", task_type=TaskType.EXTRACTION
+        id=122, name="1040 Document Extraction", task_type=TaskType.DOCUMENT_EXTRACTION
     )
 
 
@@ -72,7 +72,7 @@ def predictions(
                 confidences={"1040": 0.7},
                 extras={},
             ),
-            Extraction(
+            DocumentExtraction(
                 document=document,
                 model=extraction_model,
                 review=auto_review,
@@ -87,7 +87,7 @@ def predictions(
                 page=0,
                 groups=set(),
             ),
-            Extraction(
+            DocumentExtraction(
                 document=document,
                 model=extraction_model,
                 review=manual_review,
@@ -112,9 +112,9 @@ def test_classifications(predictions: "PredictionList[Prediction]") -> None:
 
 
 def test_extractions(predictions: "PredictionList[Prediction]") -> None:
-    (first_extraction, second_extraction) = predictions.extractions
-    assert isinstance(first_extraction, Extraction)
-    assert isinstance(second_extraction, Extraction)
+    (first_extraction, second_extraction) = predictions.document_extractions
+    assert isinstance(first_extraction, DocumentExtraction)
+    assert isinstance(second_extraction, DocumentExtraction)
 
 
 def test_slice_is_prediction_list(predictions: "PredictionList[Prediction]") -> None:
@@ -153,7 +153,6 @@ def test_where_model(
     assert classification in filtered
     assert first_name not in filtered
     assert last_name not in filtered
-
 
 
 def test_where_label(predictions: "PredictionList[Prediction]") -> None:

--- a/tests/results/test_predictions.py
+++ b/tests/results/test_predictions.py
@@ -1,4 +1,4 @@
-from indico_toolkit.results import AutoReviewable, Prediction
+from indico_toolkit.results import Extraction, Prediction
 
 
 def test_confidence() -> None:
@@ -17,12 +17,13 @@ def test_confidence() -> None:
 
 
 def test_autoreviewable() -> None:
-    prediction = AutoReviewable(
+    prediction = Extraction(
         document=None,  # type: ignore[arg-type]
         model=None,  # type: ignore[arg-type]
         review=None,
         label="Label",
         confidences={"Label": 0.5},
+        text="Value",
         extras=None,  # type: ignore[arg-type]
         accepted=False,
         rejected=False,

--- a/tests/results/test_predictions.py
+++ b/tests/results/test_predictions.py
@@ -16,7 +16,7 @@ def test_confidence() -> None:
     assert prediction.confidence == 1.0
 
 
-def test_autoreviewable() -> None:
+def test_extractions() -> None:
     prediction = Extraction(
         document=None,  # type: ignore[arg-type]
         model=None,  # type: ignore[arg-type]
@@ -24,6 +24,7 @@ def test_autoreviewable() -> None:
         label="Label",
         confidences={"Label": 0.5},
         text="Value",
+        page=0,
         extras=None,  # type: ignore[arg-type]
         accepted=False,
         rejected=False,


### PR DESCRIPTION
Based on recent experience working with Document and Form Extraction models in the same workflow, this PR improves the Extraction types and PredictionList API.

Previously, Document Extractions and Form Extractions were entirely separate:

```python
class AutoReviwable(Prediction):
    label: str
    confidence: float
    accepted: bool
    rejected: bool

class Extraction(AutoReviewable):
    text: str
    page: int
    start: int
    end: int
    groups: set[Group]

class FormExtraction(AutoReviewable):
   text: str
   page: int
   top: int
   left: int
   right: int
   bottom: int
   checked: bool
   signed: bool

class PredictionList:
    @property
    def classifications(self) -> PredictionList[Classification]:
        return self.oftype(Classification)

    @property
    def extractions(self) -> PredictionList[Extraction]:
        return self.oftype(Extraction)

    @property
    def form_extractions(self) -> PredictionList[FormExtraction]:
        return self.oftype(FormExtraction)

    @property
    def unbundlings(self) -> PredictionList[Unbundling]:
        return self.oftype(Unbundling)
```

It was not possible to type-safely get a list of both Document and Form Extractions for confidence thresholding, downselection, and text normalization.

This PR changes Extraction Polymorphism:

```python
class Extraction(Prediction):
    label: str
    confidence: float
    text: str
    page: int
    accepted: bool
    rejected: bool

class DocumentExtraction(Extraction):
    start: int
    end: int
    groups: set[Group]

class FormExtraction(Extraction):
   top: int
   left: int
   right: int
   bottom: int
   checked: bool
   signed: bool

class PredictionList:
    @property
    def classifications(self) -> PredictionList[Classification]:
        return self.oftype(Classification)

    @property
    def document_extractions(self) -> PredictionList[DocumentExtraction]:
        return self.oftype(DocumentExtraction)

    @property
    def extractions(self) -> PredictionList[Extraction]:
        return self.oftype(Extraction)

    @property
    def form_extractions(self) -> PredictionList[FormExtraction]:
        return self.oftype(FormExtraction)

    @property
    def unbundlings(self) -> PredictionList[Unbundling]:
        return self.oftype(Unbundling)
```

`PredictionList.extractions` is now a list of all `DocumentExtraction`s and `FormExtraction`s as `Extraction`s with type information to work with `label`, `confidence`, `text`, `page`, `accepted`, and `rejected`. `PredictionList.document_extractions` and `PredictionList.form_extractions` can be used to get more specific types when spans or bounding box information is needed.

This change also supports the addition of `PredictionList.where(page=...)` and `PredictionList.where(page_in=...)`.