### PR TITLE
Result File Dataclasses Maintenance

### DIFF
--- a/indico_toolkit/results/document.py
+++ b/indico_toolkit/results/document.py
@@ -8,7 +8,6 @@ class Document:
     id: int
     name: str
     etl_output_url: str
-    full_text_url: str
 
     # Auto review changes must reproduce all model sections that were present in the
     # original result file. This may not be possible from the predictions alone--if a
@@ -26,14 +25,12 @@ class Document:
         document_results = get(result, dict, "results", "document", "results")
         model_names = frozenset(document_results.keys())
         etl_output_url = get(result, str, "etl_output")
-        full_text_url = etl_output_url.replace("etl_output.json", "full_text.txt")
 
         return Document(
             # v1 result files don't include document IDs or filenames.
             id=None,  # type: ignore[arg-type]
             name=None,  # type: ignore[arg-type]
             etl_output_url=etl_output_url,
-            full_text_url=full_text_url,
             _model_sections=model_names,
         )
 
@@ -45,12 +42,10 @@ class Document:
         model_results = get(document, dict, "model_results", "ORIGINAL")
         model_ids = frozenset(model_results.keys())
         etl_output_url = get(document, str, "etl_output")
-        full_text_url = etl_output_url.replace("etl_output.json", "full_text.txt")
 
         return Document(
             id=get(document, int, "submissionfile_id"),
             name=get(document, str, "input_filename"),
             etl_output_url=etl_output_url,
-            full_text_url=full_text_url,
             _model_sections=model_ids,
         )

--- a/indico_toolkit/results/result.py
+++ b/indico_toolkit/results/result.py
@@ -19,10 +19,10 @@ if TYPE_CHECKING:
 class Result:
     version: int
     submission_id: int
-    documents: "list[Document]"
-    models: "list[ModelGroup]"
+    documents: "tuple[Document, ...]"
+    models: "tuple[ModelGroup, ...]"
     predictions: "PredictionList[Prediction]"
-    reviews: "list[Review]"
+    reviews: "tuple[Review, ...]"
 
     @property
     def rejected(self) -> bool:
@@ -88,10 +88,10 @@ class Result:
         return Result(
             version=version,
             submission_id=submission_id,
-            documents=[document],
-            models=models,
+            documents=(document,),
+            models=tuple(models),
             predictions=predictions,
-            reviews=sorted(reviews),
+            reviews=tuple(sorted(reviews)),
         )
 
     @staticmethod
@@ -141,8 +141,8 @@ class Result:
         return Result(
             version=version,
             submission_id=submission_id,
-            documents=documents,
-            models=models,
+            documents=tuple(documents),
+            models=tuple(models),
             predictions=predictions,
-            reviews=reviews,
+            reviews=tuple(reviews),
         )

--- a/tests/results/test_predictionlist.py
+++ b/tests/results/test_predictionlist.py
@@ -21,7 +21,6 @@ def document() -> Document:
         id=2922,
         name="1040_filled.tiff",
         etl_output_url="indico-file:///storage/submission/2922/etl_output.json",
-        full_text_url="indico-file:///storage/submission/2922/full_text.txt",
         _model_sections=frozenset({"124", "123", "122", "121"}),
     )
 


### PR DESCRIPTION
- Cleanup / refactor v3 normalization for loops
- Make document, model, and review sequences immutable on the frozen Result dataclass
- Remove the derived `Document.etl_output_url` attribute (it's now handled by etloutput dataclasses)