### PR TITLE
Prediction List Improvements for Result File Dataclasses

### DIFF
--- a/indico_toolkit/results/predictionlist.py
+++ b/indico_toolkit/results/predictionlist.py
@@ -148,10 +148,10 @@ class PredictionList(List[PredictionType]):
         review_in: "Container[Review | ReviewType | None]" = {ReviewUnspecified},
         label: "str | None" = None,
         label_in: "Container[str] | None" = None,
-        min_confidence: "float | None" = None,
-        max_confidence: "float | None" = None,
         page: "int | None" = None,
         page_in: "Collection[int] | None" = None,
+        min_confidence: "float | None" = None,
+        max_confidence: "float | None" = None,
         accepted: "bool | None" = None,
         rejected: "bool | None" = None,
         checked: "bool | None" = None,
@@ -161,7 +161,7 @@ class PredictionList(List[PredictionType]):
         Return a new prediction list containing predictions that match
         all of the specified filters.
 
-        predicate: predictions for which this function returns True.
+        predicate: predictions for which this function returns True,
         document: predictions from this document,
         document_in: predictions from these documents,
         model: predictions from this model, task type, or name,
@@ -169,15 +169,15 @@ class PredictionList(List[PredictionType]):
         review: predictions from this review or review type,
         review_in: predictions from these reviews or review types,
         label: predictions with this label,
-        label_in: predictions with one of these labels,
+        label_in: predictions with these labels,
+        page: extractions/unbundlings on this page,
+        page_in: extractions/unbundlings on these pages,
         min_confidence: predictions with confidence >= this threshold,
         max_confidence: predictions with confidence <= this threshold,
-        page: extractions/unbundlings on this page,
-        page_in: extractions/unbundlings on one of these pages,
-        accepted: extractions that have been accepted,
-        rejected: extractions that have been rejected,
-        checked: form extractions that are checked,
-        signed: form extractions that are signed,
+        accepted: extractions that have or haven't been accepted,
+        rejected: extractions that have or haven't been rejected,
+        checked: form extractions that are or aren't checked,
+        signed: form extractions that are or aren't signed.
         """
         predicates = []
 

--- a/indico_toolkit/results/predictionlist.py
+++ b/indico_toolkit/results/predictionlist.py
@@ -141,8 +141,11 @@ class PredictionList(List[PredictionType]):
         predicate: "Callable[[PredictionType], bool] | None" = None,
         *,
         document: "Document | None" = None,
+        document_in: "Container[Document] | None" = None,
         model: "ModelGroup | TaskType | str | None" = None,
+        model_in: "Container[ModelGroup | TaskType | str] | None" = None,
         review: "Review | ReviewType | None" = ReviewUnspecified,
+        review_in: "Container[Review | ReviewType | None]" = {ReviewUnspecified},
         label: "str | None" = None,
         label_in: "Container[str] | None" = None,
         min_confidence: "float | None" = None,
@@ -160,8 +163,11 @@ class PredictionList(List[PredictionType]):
 
         predicate: predictions for which this function returns True.
         document: predictions from this document,
+        document_in: predictions from these documents,
         model: predictions from this model, task type, or name,
+        model_in: predictions from these models, task types, or names,
         review: predictions from this review or review type,
+        review_in: predictions from these reviews or review types,
         label: predictions with this label,
         label_in: predictions with one of these labels,
         min_confidence: predictions with confidence >= this threshold,
@@ -181,12 +187,24 @@ class PredictionList(List[PredictionType]):
         if document is not None:
             predicates.append(lambda prediction: prediction.document == document)
 
+        if document_in is not None:
+            predicates.append(lambda prediction: prediction.document in document_in)
+
         if model is not None:
             predicates.append(
                 lambda prediction: (
                     prediction.model == model
                     or prediction.model.task_type == model
                     or prediction.model.name == model
+                )
+            )
+
+        if model_in is not None:
+            predicates.append(
+                lambda prediction: (
+                    prediction.model in model_in
+                    or prediction.model.task_type in model_in
+                    or prediction.model.name in model_in
                 )
             )
 
@@ -197,6 +215,17 @@ class PredictionList(List[PredictionType]):
                     or (
                         prediction.review is not None
                         and prediction.review.type == review
+                    )
+                )
+            )
+
+        if review_in != {ReviewUnspecified}:
+            predicates.append(
+                lambda prediction: (
+                    prediction.review in review_in
+                    or (
+                        prediction.review is not None
+                        and prediction.review.type in review_in
                     )
                 )
             )

--- a/indico_toolkit/results/predictionlist.py
+++ b/indico_toolkit/results/predictionlist.py
@@ -101,6 +101,24 @@ class PredictionList(List[PredictionType]):
 
         return grouped
 
+    def groupbyiter(
+        self, keys: "Callable[[PredictionType], Iterable[KeyType]]"
+    ) -> "dict[KeyType, Self]":
+        """
+        Group predictions into a dictionary using `key` to derive an iterable of keys.
+        E.g. `key=attrgetter("groups")` or `key=attrgetter("pages")`.
+
+        Each prediction is associated with every key in the iterable individually.
+        If the iterable is empty, the prediction is not included in any group.
+        """
+        grouped = defaultdict(type(self))  # type: ignore[var-annotated]
+
+        for prediction in self:
+            for derived_key in keys(prediction):
+                grouped[derived_key].append(prediction)
+
+        return grouped
+
     def oftype(self, type: "type[OfType]") -> "PredictionList[OfType]":
         """
         Return a new prediction list containing predictions of type `type`.

--- a/tests/results/test_predictionlist.py
+++ b/tests/results/test_predictionlist.py
@@ -140,9 +140,10 @@ def test_groupby(
 ) -> None:
     first_name, last_name = predictions.extractions
     predictions_by_groups = predictions.extractions.groupby(attrgetter("groups"))
-    assert len(predictions_by_groups) == 2
-    assert predictions_by_groups[frozenset({group_alpha})] == [first_name]
-    assert predictions_by_groups[frozenset({group_alpha, group_bravo})] == [last_name]
+    assert predictions_by_groups == {
+        frozenset({group_alpha}): [first_name],
+        frozenset({group_alpha, group_bravo}): [last_name],
+    }
 
 
 def test_groupbyiter(
@@ -150,9 +151,10 @@ def test_groupbyiter(
 ) -> None:
     first_name, last_name = predictions.extractions
     predictions_by_group = predictions.extractions.groupbyiter(attrgetter("groups"))
-    assert len(predictions_by_group) == 2
-    assert predictions_by_group[group_alpha] == [first_name, last_name]
-    assert predictions_by_group[group_bravo] == [last_name]
+    assert predictions_by_group == {
+        group_alpha: [first_name, last_name],
+        group_bravo: [last_name],
+    }
 
 
 def test_orderby(predictions: "PredictionList[Prediction]") -> None:

--- a/tests/results/test_predictionlist.py
+++ b/tests/results/test_predictionlist.py
@@ -6,6 +6,7 @@ from indico_toolkit.results import (
     Classification,
     Document,
     DocumentExtraction,
+    Group,
     ModelGroup,
     Prediction,
     PredictionList,
@@ -54,12 +55,24 @@ def manual_review() -> Review:
 
 
 @pytest.fixture
+def group_alpha() -> Group:
+    return Group(id=12345, name="Alpha", index=0)
+
+
+@pytest.fixture
+def group_bravo() -> Group:
+    return Group(id=12345, name="Bravo", index=0)
+
+
+@pytest.fixture
 def predictions(
     document: Document,
     classification_model: ModelGroup,
     extraction_model: ModelGroup,
     auto_review: Review,
     manual_review: Review,
+    group_alpha: Group,
+    group_bravo: Group,
 ) -> "PredictionList[Prediction]":
     return PredictionList(
         [
@@ -84,7 +97,7 @@ def predictions(
                 start=352,
                 end=356,
                 page=0,
-                groups=set(),
+                groups={group_alpha},
             ),
             DocumentExtraction(
                 document=document,
@@ -99,7 +112,7 @@ def predictions(
                 start=357,
                 end=360,
                 page=1,
-                groups=set(),
+                groups={group_alpha, group_bravo},
             ),
         ]
     )
@@ -111,7 +124,7 @@ def test_classifications(predictions: "PredictionList[Prediction]") -> None:
 
 
 def test_extractions(predictions: "PredictionList[Prediction]") -> None:
-    (first_extraction, second_extraction) = predictions.document_extractions
+    first_extraction, second_extraction = predictions.extractions
     assert isinstance(first_extraction, DocumentExtraction)
     assert isinstance(second_extraction, DocumentExtraction)
 
@@ -122,9 +135,30 @@ def test_slice_is_prediction_list(predictions: "PredictionList[Prediction]") -> 
     assert isinstance(predictions, PredictionList)
 
 
+def test_groupby(
+    predictions: "PredictionList[Prediction]", group_alpha: Group, group_bravo: Group
+) -> None:
+    first_name, last_name = predictions.extractions
+    predictions_by_groups = predictions.extractions.groupby(attrgetter("groups"))
+    assert len(predictions_by_groups) == 2
+    assert predictions_by_groups[frozenset({group_alpha})] == [first_name]
+    assert predictions_by_groups[frozenset({group_alpha, group_bravo})] == [last_name]
+
+
+def test_groupbyiter(
+    predictions: "PredictionList[Prediction]", group_alpha: Group, group_bravo: Group
+) -> None:
+    first_name, last_name = predictions.extractions
+    predictions_by_group = predictions.extractions.groupbyiter(attrgetter("groups"))
+    assert len(predictions_by_group) == 2
+    assert predictions_by_group[group_alpha] == [first_name, last_name]
+    assert predictions_by_group[group_bravo] == [last_name]
+
+
 def test_orderby(predictions: "PredictionList[Prediction]") -> None:
+    classification, first_name, last_name = predictions
     predictions = predictions.orderby(attrgetter("confidence"), reverse=True)
-    assert predictions[0].confidence == 0.9
+    assert predictions == [last_name, first_name, classification]
 
 
 def test_where_document(
@@ -133,115 +167,109 @@ def test_where_document(
     assert predictions.where(document=document) == predictions
 
 
+def test_where_document_in(
+    predictions: "PredictionList[Prediction]", document: Document
+) -> None:
+    assert predictions.where(document_in={document}) == predictions
+    assert predictions.where(document_in={}) == []
+
+
 def test_where_model(
     predictions: "PredictionList[Prediction]", classification_model: ModelGroup
 ) -> None:
+    (classification,) = predictions.classifications
+    assert predictions.where(model=classification_model) == [classification]
+    assert predictions.where(model=TaskType.CLASSIFICATION) == [classification]
+    assert predictions.where(model="Tax Classification") == [classification]
+
+
+def test_where_model_in(
+    predictions: "PredictionList[Prediction]", classification_model: ModelGroup
+) -> None:
     classification, first_name, last_name = predictions
+    assert predictions.where(model_in={classification_model}) == [classification]
+    assert predictions.where(model_in={TaskType.CLASSIFICATION}) == [classification]
+    assert predictions.where(
+        model_in={TaskType.CLASSIFICATION, TaskType.DOCUMENT_EXTRACTION}
+    ) == [classification, first_name, last_name]
+    assert predictions.where(model_in={"Tax Classification"}) == [classification]
+    assert predictions.where(
+        model_in={"Tax Classification", "1040 Document Extraction"}
+    ) == [classification, first_name, last_name]
+    assert predictions.where(model_in={}) == []
 
-    filtered = predictions.where(model=classification_model)
-    assert classification in filtered
-    assert first_name not in filtered
-    assert last_name not in filtered
 
-    filtered = predictions.where(model=TaskType.CLASSIFICATION)
-    assert classification in filtered
-    assert first_name not in filtered
-    assert last_name not in filtered
+def test_where_review(
+    predictions: "PredictionList[Prediction]", auto_review: Review
+) -> None:
+    classification, first_name, last_name = predictions
+    assert predictions.where(review=None) == [classification]
+    assert predictions.where(review=auto_review) == [first_name]
+    assert predictions.where(review=ReviewType.MANUAL) == [last_name]
 
-    filtered = predictions.where(model="Tax Classification")
-    assert classification in filtered
-    assert first_name not in filtered
-    assert last_name not in filtered
+def test_where_review_in(
+    predictions: "PredictionList[Prediction]", auto_review: Review
+) -> None:
+    classification, first_name, last_name = predictions
+    assert predictions.where(review_in={None}) == [classification]
+    assert predictions.where(
+        review_in={None, auto_review}
+    ) == [classification, first_name]
+    assert predictions.where(
+        review_in={auto_review, ReviewType.MANUAL}
+    ) == [first_name, last_name]
+    assert predictions.where(review_in={}) == []
 
 
 def test_where_label(predictions: "PredictionList[Prediction]") -> None:
-    classification, first_name, last_name = predictions
+    first_name, _ = predictions.extractions
+    assert predictions.where(label="First Name") == [first_name]
 
-    filtered = predictions.where(label="First Name")
-    assert classification not in filtered
-    assert first_name in filtered
-    assert last_name not in filtered
 
-    filtered = predictions.where(label_in=("First Name", "Last Name"))
-    assert classification not in filtered
-    assert first_name in filtered
-    assert last_name in filtered
+def test_where_label_in(predictions: "PredictionList[Prediction]") -> None:
+    first_name, last_name = predictions.extractions
+    assert predictions.where(
+        label_in=("First Name", "Last Name")
+    ) == [first_name, last_name]
 
 
 def test_where_confidence(predictions: "PredictionList[Prediction]") -> None:
     conf_70, conf_80, conf_90 = predictions
-
-    filtered = predictions.where(min_confidence=0.9)
-    assert conf_70 not in filtered
-    assert conf_80 not in filtered
-    assert conf_90 in filtered
-
-    filtered = predictions.where(min_confidence=0.75, max_confidence=0.85)
-    assert conf_70 not in filtered
-    assert conf_80 in filtered
-    assert conf_90 not in filtered
-
-    filtered = predictions.where(max_confidence=0.7)
-    assert conf_70 in filtered
-    assert conf_80 not in filtered
-    assert conf_90 not in filtered
+    assert predictions.where(min_confidence=0.9) == [conf_90]
+    assert predictions.where(min_confidence=0.75, max_confidence=0.85) == [conf_80]
+    assert predictions.where(max_confidence=0.7) == [conf_70]
 
 
 def test_where_page(predictions: "PredictionList[Prediction]") -> None:
-    classification, first_name, last_name = predictions
+    first_name, _ = predictions.extractions
+    assert predictions.where(page=0) == [first_name]
 
-    filtered = predictions.where(page=0)
-    assert classification not in filtered
-    assert first_name in filtered
-    assert last_name not in filtered
 
-    filtered = predictions.where(page_in=(0, 1))
-    assert classification not in filtered
-    assert first_name in filtered
-    assert last_name in filtered
+def test_where_page_in(predictions: "PredictionList[Prediction]") -> None:
+    first_name, last_name = predictions.extractions
+    assert predictions.where(page_in=(0, 1)) == [first_name, last_name]
 
 
 def test_where_accepted(predictions: "PredictionList[Prediction]") -> None:
-    _, first_name, last_name = predictions
+    first_name, last_name = predictions.extractions
     predictions.unaccept()
 
-    filtered = predictions.where(accepted=True)
-    assert first_name not in filtered
-    assert last_name not in filtered
-
-    filtered = predictions.where(accepted=False)
-    assert first_name in filtered
-    assert last_name in filtered
+    assert predictions.where(accepted=True) == []
+    assert predictions.where(accepted=False) == [first_name, last_name]
 
     predictions.accept()
 
-    filtered = predictions.where(accepted=False)
-    assert first_name not in filtered
-    assert last_name not in filtered
-
-    filtered = predictions.where(accepted=True)
-    assert first_name in filtered
-    assert last_name in filtered
-
+    assert predictions.where(accepted=False) == []
+    assert predictions.where(accepted=True) == [first_name, last_name]
 
 def test_where_rejected(predictions: "PredictionList[Prediction]") -> None:
-    _, first_name, last_name = predictions
+    first_name, last_name = predictions.extractions
     predictions.unreject()
 
-    filtered = predictions.where(rejected=True)
-    assert first_name not in filtered
-    assert last_name not in filtered
-
-    filtered = predictions.where(rejected=False)
-    assert first_name in filtered
-    assert last_name in filtered
+    assert predictions.where(rejected=True) == []
+    assert predictions.where(rejected=False) == [first_name, last_name]
 
     predictions.reject()
 
-    filtered = predictions.where(rejected=False)
-    assert first_name not in filtered
-    assert last_name not in filtered
-
-    filtered = predictions.where(rejected=True)
-    assert first_name in filtered
-    assert last_name in filtered
+    assert predictions.where(rejected=False) == []
+    assert predictions.where(rejected=True) == [first_name, last_name]


### PR DESCRIPTION
Expanding the PredictionList API to simplify some common patterns seen in auto review and custom output.

<br>

**Group by Set of Linked Labels / Pages**

Predictions can now be grouped by mutable collections, including a document extractions's set of linked label groups and an unbundling's list of pages. Internally, mutable collections are converted to their immutable variant before being used as a dictionary key.

Before:
```python
extractions.groupby(lambda extraction: frozenset(extraction.groups))
unbundlings.groupby(lambda unbundling: tuple(unbundling.pages))
```

After:
```python
extractions.groupby(attrgetter("groups"))
unbundlings.groupby(attrgetter("pages"))
```

<br>

**Group by Individual Linked Labels / Pages**

The new `.groupbyiter()` method groups each prediction with every key in an iterable individually. This is particularly useful for a document extraction's set of linked label groups. While it's sometimes desirable to group by the entire set as `.groupby()` does, it's more often desirable to group by each linked label group individually.

Before:
```python
extractions_by_group: Mapping[Group, Extraction] = defaultdict(PredictionList)

for extraction in extractions:
    for group in extraction.groups:
        extractions_by_group[group].append(extraction)
```

After:
```python
extractions.groupbyiter(attrgetter("groups"))
```

The `.groupby()` and `.groupbyiter()` [unit tests](https://github.com/IndicoDataSolutions/Indico-Solutions-Toolkit/blob/be7e3ae84336834d6b3b58cf94f6687e04474ff8/tests/results/test_predictionlist.py#L138) are good examples of the difference in behavior:
```python
>>> predictions.extractions.groupby(attrgetter("groups"))
{
    frozenset({group_alpha}): [first_name],
    frozenset({group_alpha, group_bravo}): [last_name],
}
>>> predictions.extractions.groupbyiter(attrgetter("groups"))
{
    group_alpha: [first_name, last_name],
    group_bravo: [last_name],
}
```

<br>

**"Where Attr In" for Documents, Models, and Reviews**

The `.where()` method has new `document_in`, `model_in`, and `review_in` keyword args to complement the existing single-value variants.

Before:
```python
predictions.where(lambda prediction: prediction.model in MODELS)
predictions.where(lambda prediction: prediction.document in DOCUMENTS)
predictions.where(lambda prediction: prediction.review in REVIEWS)
```
After:
```python
predictions.where(model_in=MODELS)
predictions.where(document_in=DOCUMENTS)
predictions.where(review_in=REVIEWS)
```