### PR TITLE
Auto Review and Downstream Polling

### DIFF
--- a/examples/poll_auto_review.py
+++ b/examples/poll_auto_review.py
@@ -30,7 +30,8 @@ async def auto_review(
 
     return AutoReviewed(
         changes=predictions.to_changes(result),
-        stp=True,  # Defaults to `False` and may be omitted.
+        reject=False,  # Defaults to `False` and may be omitted.
+        stp=False,  # Defaults to `False` and may be omitted.
     )
 
 

--- a/examples/poll_auto_review.py
+++ b/examples/poll_auto_review.py
@@ -1,0 +1,56 @@
+"""
+A feature-complete auto review polling script that incorporates asyncio,
+automatic retry, result file dataclasses, and etl output dataclasses.
+
+Max workers, spawn rate, etl output loading, and retry behavior are all configurable.
+See the `AutoReviewPoller` class definition.
+"""
+
+import asyncio
+import sys
+
+from indico import IndicoConfig
+
+from indico_toolkit.polling import AutoReviewPoller, AutoReviewed
+from indico_toolkit.etloutput import EtlOutput
+from indico_toolkit.results import Result, Document
+
+
+async def auto_review(
+    result: Result, etl_outputs: dict[Document, EtlOutput]
+) -> AutoReviewed:
+    """
+    Apply auto review rules to predictions and determine straight through processing.
+    Any IO performed (network requests, file reads/writes, etc) must be awaited to
+    avoid blocking the asyncio loop that schedules this coroutine.
+    """
+    predictions = result.pre_review
+
+    # Apply auto review rules.
+
+    return AutoReviewed(
+        changes=predictions.to_changes(result),
+        stp=False,  # Defaults to `False` and can be omitted.
+    )
+
+
+if __name__ == "__main__":
+    import logging
+
+    logging.basicConfig(
+        format=(
+            r"[%(asctime)s] "
+            r"%(name)s:%(funcName)s():%(lineno)s: "
+            r"%(levelname)s %(message)s"
+        ),
+        level=logging.INFO,
+        force=True,
+    )
+    workflow_id = int(sys.argv[1])
+    asyncio.run(
+        AutoReviewPoller(
+            IndicoConfig(),  # Host and token read from environment variables.
+            workflow_id,
+            auto_review,
+        ).poll_forever()
+    )

--- a/examples/poll_auto_review.py
+++ b/examples/poll_auto_review.py
@@ -30,7 +30,7 @@ async def auto_review(
 
     return AutoReviewed(
         changes=predictions.to_changes(result),
-        stp=False,  # Defaults to `False` and can be omitted.
+        stp=True,  # Defaults to `False` and may be omitted.
     )
 
 
@@ -49,7 +49,10 @@ if __name__ == "__main__":
     workflow_id = int(sys.argv[1])
     asyncio.run(
         AutoReviewPoller(
-            IndicoConfig(),  # Host and token read from environment variables.
+            IndicoConfig(
+                host="try.indico.io",
+                api_token_path="indico_api_token.txt",
+            ),
             workflow_id,
             auto_review,
         ).poll_forever()

--- a/indico_toolkit/polling/__init__.py
+++ b/indico_toolkit/polling/__init__.py
@@ -1,0 +1,8 @@
+from .autoreview import AutoReviewed, AutoReviewPoller
+from .downstream import DownstreamPoller
+
+__all__ = (
+    "AutoReviewed",
+    "AutoReviewPoller",
+    "DownstreamPoller",
+)

--- a/indico_toolkit/polling/autoreview.py
+++ b/indico_toolkit/polling/autoreview.py
@@ -78,8 +78,8 @@ class AutoReviewPoller:
             jitter=retry_jitter,
         )
         self._worker_slots = asyncio.Semaphore(worker_count)
-        self._worker_queue: WorkerQueue = asyncio.Queue(1)
-        self._processing_submission_ids: set[SubmissionId] = set()
+        self._worker_queue: "WorkerQueue" = asyncio.Queue(1)
+        self._processing_submission_ids: "set[SubmissionId]" = set()
 
     async def poll_forever(self) -> "NoReturn":  # type: ignore[misc]
         logger.info(
@@ -111,7 +111,7 @@ class AutoReviewPoller:
 
         while True:
             try:
-                submission_ids: set[int] = await self._client_call(
+                submission_ids: "set[SubmissionId]" = await self._client_call(
                     SubmissionIdsPendingAutoReview(self._workflow_id)
                 )
             except Exception:
@@ -133,7 +133,7 @@ class AutoReviewPoller:
                 await self._worker_queue.put((submission_id, worker))
                 await asyncio.sleep(1 / self._spawn_rate)
 
-    async def _worker(self, submission_id: SubmissionId) -> None:
+    async def _worker(self, submission_id: "SubmissionId") -> None:
         """
         Process a single submission by retrieving submission metadata, the result file,
         etl output, calling `self._auto_review`, and submitting changes.

--- a/indico_toolkit/polling/autoreview.py
+++ b/indico_toolkit/polling/autoreview.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class AutoReviewed:
     changes: "dict[str, Any] | list[dict[str, Any]]"
+    reject: bool = False
     stp: bool = False
 
 
@@ -170,6 +171,7 @@ class AutoReviewPoller:
             SubmitReview(
                 submission_id,
                 changes=auto_reviewed.changes,
+                rejected=auto_reviewed.reject,
                 force_complete=auto_reviewed.stp,
             )
         )

--- a/indico_toolkit/polling/autoreview.py
+++ b/indico_toolkit/polling/autoreview.py
@@ -20,7 +20,7 @@ from .queries import SubmissionIdsPendingAutoReview
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
-    from typing import Any, TypeAlias
+    from typing import Any, NoReturn, TypeAlias
 
     SubmissionId: TypeAlias = int
     Worker: TypeAlias = asyncio.Task[None]
@@ -81,7 +81,7 @@ class AutoReviewPoller:
         self._worker_queue: WorkerQueue = asyncio.Queue(1)
         self._processing_submission_ids: set[SubmissionId] = set()
 
-    async def run(self) -> None:
+    async def poll_forever(self) -> "NoReturn":  # type: ignore[misc]
         logger.info(
             "Starting auto review poller for: "
             f"host={self._config.host} "

--- a/indico_toolkit/polling/autoreview.py
+++ b/indico_toolkit/polling/autoreview.py
@@ -19,7 +19,7 @@ from ..retry import retry
 from .queries import SubmissionIdsPendingAutoReview
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Mapping
+    from collections.abc import Awaitable, Callable
     from typing import Any, TypeAlias
 
     SubmissionId: TypeAlias = int
@@ -45,7 +45,7 @@ class AutoReviewPoller:
         self,
         config: IndicoConfig,
         workflow_id: int,
-        auto_review: "Callable[[Result, Mapping[Document, EtlOutput]], Awaitable[AutoReviewed]]",  # noqa: E501
+        auto_review: "Callable[[Result, dict[Document, EtlOutput]], Awaitable[AutoReviewed]]",  # noqa: E501
         *,
         concurrency: int = 8,
         enqueue_delay: float = 1,

--- a/indico_toolkit/polling/autoreview.py
+++ b/indico_toolkit/polling/autoreview.py
@@ -1,0 +1,202 @@
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from indico import AsyncIndicoClient, IndicoConfig  # type: ignore[import-untyped]
+from indico.errors import IndicoError  # type: ignore[import-untyped]
+from indico.queries import (  # type: ignore[import-untyped]
+    GetSubmission,
+    JobStatus,
+    RetrieveStorageObject,
+    SubmitReview,
+)
+
+from .. import etloutput, results
+from ..etloutput import EtlOutput
+from ..results import Document, Result
+from ..retry import retry
+from .queries import SubmissionIdsPendingAutoReview
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Mapping
+    from typing import Any, TypeAlias
+
+    SubmissionId: TypeAlias = int
+    Worker: TypeAlias = asyncio.Task[None]
+    WorkerQueue: TypeAlias = asyncio.Queue[tuple[SubmissionId, Worker]]
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AutoReviewed:
+    changes: "dict[str, Any] | list[dict[str, Any]]"
+    stp: bool = False
+
+
+class AutoReviewPoller:
+    """
+    Polls for submissions requiring auto review, processes them concurrently,
+    and submits the review results.
+    """
+
+    def __init__(
+        self,
+        config: IndicoConfig,
+        workflow_id: int,
+        auto_review: "Callable[[Result, Mapping[Document, EtlOutput]], Awaitable[AutoReviewed]]",  # noqa: E501
+        *,
+        concurrency: int = 8,
+        enqueue_delay: float = 1,
+        poll_delay: float = 30,
+        load_etl_output: bool = True,
+        load_text: bool = True,
+        load_tokens: bool = True,
+        load_tables: bool = False,
+        retry_count: int = 4,
+        retry_wait: float = 1,
+        retry_backoff: float = 4,
+        retry_jitter: float = 0.5,
+    ):
+        self._config = config
+        self._workflow_id = workflow_id
+        self._concurrency = concurrency
+        self._auto_review = auto_review
+        self._enqueue_delay = enqueue_delay
+        self._poll_delay = poll_delay
+        self._load_etl_output = load_etl_output
+        self._load_text = load_text
+        self._load_tokens = load_tokens
+        self._load_tables = load_tables
+
+        self._retry = retry(
+            IndicoError,
+            retry_count,
+            retry_wait,
+            retry_backoff,
+            retry_jitter,
+        )
+        self._worker_slots = asyncio.Semaphore(concurrency)
+        self._worker_queue: WorkerQueue = asyncio.Queue(1)
+        self._processing_submission_ids: set[SubmissionId] = set()
+
+    async def run(self) -> None:
+        logger.info(
+            "Starting auto review poller for: "
+            f"host={self._config.host} "
+            f"workflow_id={self._workflow_id}"
+            f"concurrency={self._concurrency}"
+        )
+
+        async with AsyncIndicoClient(self._config) as client:
+            self._client_call = self._retry(client.call)
+            await asyncio.gather(
+                self._spawn_workers(),
+                *(self._reap_workers() for _ in range(self._concurrency)),
+            )
+
+    async def _retrieve_storage_object(self, url: str) -> object:
+        return await self._client_call(RetrieveStorageObject(url))
+
+    async def _spawn_workers(self) -> None:
+        """
+        Poll for submissions pending auto review and spawn workers to process them.
+        `self._worker_slots` limits the number of workers that can run concurrently.
+        Submission IDs in progress are tracked with `self._processing_submission_ids`.
+        """
+        logger.info(
+            f"Polling submissions pending auto review every {self._poll_delay} seconds"
+        )
+
+        while True:
+            try:
+                submission_ids: set[int] = await self._client_call(
+                    SubmissionIdsPendingAutoReview(self._workflow_id)
+                )
+            except Exception:
+                logger.exception("Error occurred while polling submissions")
+                await asyncio.sleep(self._poll_delay)
+                continue
+
+            submission_ids -= self._processing_submission_ids
+
+            if not submission_ids:
+                await asyncio.sleep(self._poll_delay)
+                continue
+
+            for submission_id in submission_ids:
+                await self._worker_slots.acquire()
+                logger.info(f"Spawning worker for {submission_id=}")
+                self._processing_submission_ids.add(submission_id)
+                worker = asyncio.create_task(self._worker(submission_id))
+                await self._worker_queue.put((submission_id, worker))
+                await asyncio.sleep(self._enqueue_delay)
+
+    async def _worker(self, submission_id: SubmissionId) -> None:
+        """
+        Process a single submission by retrieving submission metadata, the result file,
+        etl output, calling `self._auto_review`, and submitting changes.
+        """
+        logger.info(f"Retrieving metadata for {submission_id=}")
+        submission = await self._client_call(GetSubmission(submission_id))
+
+        logger.info(f"Retrieving results for {submission_id=}")
+        result = await results.load_async(
+            submission.result_file,
+            reader=self._retrieve_storage_object,
+        )
+
+        if self._load_etl_output:
+            logger.info(f"Retrieving etl output for {submission_id=}")
+            etl_outputs = {
+                document: await etloutput.load_async(
+                    document.etl_output_url,
+                    reader=self._retrieve_storage_object,
+                    text=self._load_text,
+                    tokens=self._load_tokens,
+                    tables=self._load_tables,
+                )
+                for document in result.documents
+            }
+        else:
+            logger.info(f"Skipping etl output for {submission_id=}")
+            etl_outputs = {}
+
+        logger.info(f"Applying auto review for {submission_id=}")
+        auto_reviewed = await self._auto_review(result, etl_outputs)
+
+        logger.info(f"Submitting auto review for {submission_id=}")
+        job = await self._client_call(
+            SubmitReview(
+                submission_id,
+                changes=auto_reviewed.changes,
+                force_complete=auto_reviewed.stp,
+            )
+        )
+        job = await self._client_call(JobStatus(job.id))
+
+        if job.status == "SUCCESS":
+            logger.info(f"Completed auto review of {submission_id=}")
+        else:
+            logger.error(
+                f"Submit failed for {submission_id=}: "
+                f"{job.status=!r} {job.result=!r}"
+            )
+
+    async def _reap_workers(self) -> None:
+        """
+        Reap completed workers, releasing their slots for new tasks. Log errors for
+        submissions that failed to process. Remove their submission IDs from
+        `self._processing_submission_ids` to be retried.
+        """
+        while True:
+            submission_id, worker = await self._worker_queue.get()
+
+            try:
+                await worker
+            except Exception:
+                logger.exception(f"Error occurred while processing {submission_id=}")
+
+            self._processing_submission_ids.remove(submission_id)
+            self._worker_slots.release()

--- a/indico_toolkit/polling/autoreview.py
+++ b/indico_toolkit/polling/autoreview.py
@@ -72,10 +72,10 @@ class AutoReviewPoller:
 
         self._retry = retry(
             IndicoError,
-            retry_count,
-            retry_wait,
-            retry_backoff,
-            retry_jitter,
+            count=retry_count,
+            wait=retry_wait,
+            backoff=retry_backoff,
+            jitter=retry_jitter,
         )
         self._worker_slots = asyncio.Semaphore(concurrency)
         self._worker_queue: WorkerQueue = asyncio.Queue(1)

--- a/indico_toolkit/polling/autoreview.py
+++ b/indico_toolkit/polling/autoreview.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from indico import AsyncIndicoClient, IndicoConfig  # type: ignore[import-untyped]
-from indico.errors import IndicoError  # type: ignore[import-untyped]
 from indico.queries import (  # type: ignore[import-untyped]
     GetSubmission,
     JobStatus,
@@ -71,7 +70,7 @@ class AutoReviewPoller:
         self._load_tables = load_tables
 
         self._retry = retry(
-            IndicoError,
+            Exception,
             count=retry_count,
             wait=retry_wait,
             backoff=retry_backoff,

--- a/indico_toolkit/polling/downstream.py
+++ b/indico_toolkit/polling/downstream.py
@@ -26,7 +26,8 @@ logger = logging.getLogger(__name__)
 
 class DownstreamPoller:
     """
-    Polls for submissions pending downstream egestion and processes them concurrently.
+    Polls for completed and failed submissions pending downstream egestion, processes
+    them concurrently, and marks them as retrieved.
     """
 
     def __init__(

--- a/indico_toolkit/polling/downstream.py
+++ b/indico_toolkit/polling/downstream.py
@@ -3,7 +3,6 @@ import logging
 from typing import TYPE_CHECKING
 
 from indico import AsyncIndicoClient, IndicoConfig  # type: ignore[import-untyped]
-from indico.errors import IndicoError  # type: ignore[import-untyped]
 from indico.queries import (  # type: ignore[import-untyped]
     GetSubmission,
     UpdateSubmission,
@@ -52,7 +51,7 @@ class DownstreamPoller:
         self._poll_delay = poll_delay
 
         self._retry = retry(
-            IndicoError,
+            Exception,
             count=retry_count,
             wait=retry_wait,
             backoff=retry_backoff,

--- a/indico_toolkit/polling/downstream.py
+++ b/indico_toolkit/polling/downstream.py
@@ -125,6 +125,8 @@ class DownstreamPoller:
         logger.info(f"Marking {submission_id=} retrieved")
         await self._client_call(UpdateSubmission(submission_id, retrieved=True))
 
+        logger.info(f"Completed dowstream of {submission_id=}")
+
     async def _reap_workers(self) -> None:
         """
         Reap completed workers, releasing their slots for new tasks. Log errors for

--- a/indico_toolkit/polling/downstream.py
+++ b/indico_toolkit/polling/downstream.py
@@ -52,10 +52,10 @@ class DownstreamPoller:
 
         self._retry = retry(
             IndicoError,
-            retry_count,
-            retry_wait,
-            retry_backoff,
-            retry_jitter,
+            count=retry_count,
+            wait=retry_wait,
+            backoff=retry_backoff,
+            jitter=retry_jitter,
         )
         self._worker_slots = asyncio.Semaphore(concurrency)
         self._worker_queue: WorkerQueue = asyncio.Queue(1)

--- a/indico_toolkit/polling/downstream.py
+++ b/indico_toolkit/polling/downstream.py
@@ -15,7 +15,7 @@ from .queries import SubmissionIdsPendingDownstream
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
-    from typing import TypeAlias
+    from typing import NoReturn, TypeAlias
 
     SubmissionId: TypeAlias = int
     Worker: TypeAlias = asyncio.Task[None]
@@ -61,7 +61,7 @@ class DownstreamPoller:
         self._worker_queue: WorkerQueue = asyncio.Queue(1)
         self._processing_submission_ids: set[SubmissionId] = set()
 
-    async def run(self) -> None:
+    async def poll_forever(self) -> "NoReturn":  # type: ignore[misc]
         logger.info(
             "Starting downstream poller for: "
             f"host={self._config.host} "

--- a/indico_toolkit/polling/downstream.py
+++ b/indico_toolkit/polling/downstream.py
@@ -1,0 +1,143 @@
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from indico import AsyncIndicoClient, IndicoConfig  # type: ignore[import-untyped]
+from indico.errors import IndicoError  # type: ignore[import-untyped]
+from indico.queries import (  # type: ignore[import-untyped]
+    GetSubmission,
+    UpdateSubmission,
+)
+from indico.types import Submission  # type: ignore[import-untyped]
+
+from ..retry import retry
+from .queries import SubmissionIdsPendingDownstream
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+    from typing import TypeAlias
+
+    SubmissionId: TypeAlias = int
+    Worker: TypeAlias = asyncio.Task[None]
+    WorkerQueue: TypeAlias = asyncio.Queue[tuple[SubmissionId, Worker]]
+
+logger = logging.getLogger(__name__)
+
+
+class DownstreamPoller:
+    """
+    Polls for submissions pending downstream egestion and processes them concurrently.
+    """
+
+    def __init__(
+        self,
+        config: IndicoConfig,
+        workflow_id: int,
+        downstream: "Callable[[Submission], Awaitable[None]]",
+        *,
+        concurrency: int = 8,
+        enqueue_delay: float = 1,
+        poll_delay: float = 30,
+        retry_count: int = 4,
+        retry_wait: float = 1,
+        retry_backoff: float = 4,
+        retry_jitter: float = 0.5,
+    ):
+        self._config = config
+        self._workflow_id = workflow_id
+        self._concurrency = concurrency
+        self._downstream = downstream
+        self._enqueue_delay = enqueue_delay
+        self._poll_delay = poll_delay
+
+        self._retry = retry(
+            IndicoError,
+            retry_count,
+            retry_wait,
+            retry_backoff,
+            retry_jitter,
+        )
+        self._worker_slots = asyncio.Semaphore(concurrency)
+        self._worker_queue: WorkerQueue = asyncio.Queue(1)
+        self._processing_submission_ids: set[SubmissionId] = set()
+
+    async def run(self) -> None:
+        logger.info(
+            "Starting downstream poller for: "
+            f"host={self._config.host} "
+            f"workflow_id={self._workflow_id}"
+            f"concurrency={self._concurrency}"
+        )
+
+        async with AsyncIndicoClient(self._config) as client:
+            self._client_call = self._retry(client.call)
+            await asyncio.gather(
+                self._spawn_workers(),
+                *(self._reap_workers() for _ in range(self._concurrency)),
+            )
+
+    async def _spawn_workers(self) -> None:
+        """
+        Poll for completed and failed submissions and spawn workers to send them
+        downstream. `self._worker_slots` limits the number of workers that can run
+        concurrently. Submission IDs in progress are tracked with
+        `self._processing_submission_ids`.
+        """
+        logger.info(
+            f"Polling submissions pending downstream every {self._poll_delay} seconds"
+        )
+
+        while True:
+            try:
+                submission_ids: set[int] = await self._client_call(
+                    SubmissionIdsPendingDownstream(self._workflow_id)
+                )
+            except Exception:
+                logger.exception("Error occurred while polling submissions")
+                await asyncio.sleep(self._poll_delay)
+                continue
+
+            submission_ids -= self._processing_submission_ids
+
+            if not submission_ids:
+                await asyncio.sleep(self._poll_delay)
+                continue
+
+            for submission_id in submission_ids:
+                await self._worker_slots.acquire()
+                logger.info(f"Spawning worker for {submission_id=}")
+                self._processing_submission_ids.add(submission_id)
+                worker = asyncio.create_task(self._worker(submission_id))
+                await self._worker_queue.put((submission_id, worker))
+                await asyncio.sleep(self._enqueue_delay)
+
+    async def _worker(self, submission_id: SubmissionId) -> None:
+        """
+        Process a single submission by retrieving submission metadata and calling
+        `self._downstream`. Once completed, mark the submission retrieved.
+        """
+        logger.info(f"Retrieving metadata for {submission_id=}")
+        submission = await self._client_call(GetSubmission(submission_id))
+
+        logger.info(f"Sending {submission_id=} downstream")
+        await self._downstream(submission)
+
+        logger.info(f"Marking {submission_id=} retrieved")
+        await self._client_call(UpdateSubmission(submission_id, retrieved=True))
+
+    async def _reap_workers(self) -> None:
+        """
+        Reap completed workers, releasing their slots for new tasks. Log errors for
+        submissions that failed to process. Remove their submission IDs from
+        `self._processing_submission_ids` to be retried.
+        """
+        while True:
+            submission_id, worker = await self._worker_queue.get()
+
+            try:
+                await worker
+            except Exception:
+                logger.exception(f"Error occurred while processing {submission_id=}")
+
+            self._processing_submission_ids.remove(submission_id)
+            self._worker_slots.release()

--- a/indico_toolkit/polling/downstream.py
+++ b/indico_toolkit/polling/downstream.py
@@ -59,8 +59,8 @@ class DownstreamPoller:
             jitter=retry_jitter,
         )
         self._worker_slots = asyncio.Semaphore(worker_count)
-        self._worker_queue: WorkerQueue = asyncio.Queue(1)
-        self._processing_submission_ids: set[SubmissionId] = set()
+        self._worker_queue: "WorkerQueue" = asyncio.Queue(1)
+        self._processing_submission_ids: "set[SubmissionId]" = set()
 
     async def poll_forever(self) -> "NoReturn":  # type: ignore[misc]
         logger.info(
@@ -90,7 +90,7 @@ class DownstreamPoller:
 
         while True:
             try:
-                submission_ids: set[int] = await self._client_call(
+                submission_ids: "set[SubmissionId]" = await self._client_call(
                     SubmissionIdsPendingDownstream(self._workflow_id)
                 )
             except Exception:
@@ -112,7 +112,7 @@ class DownstreamPoller:
                 await self._worker_queue.put((submission_id, worker))
                 await asyncio.sleep(1 / self._spawn_rate)
 
-    async def _worker(self, submission_id: SubmissionId) -> None:
+    async def _worker(self, submission_id: "SubmissionId") -> None:
         """
         Process a single submission by retrieving submission metadata and calling
         `self._downstream`. Once completed, mark the submission retrieved.

--- a/indico_toolkit/polling/queries.py
+++ b/indico_toolkit/polling/queries.py
@@ -1,0 +1,65 @@
+from typing import Any
+
+from indico.queries import GraphQLRequest  # type: ignore[import-untyped]
+
+
+class SubmissionIdsPendingAutoReview(GraphQLRequest):  # type: ignore[misc]
+    QUERY = """
+    query SubmissionIdsPendingAutoReview($workflowIds: [Int]) {
+        submissions(
+            desc: false
+            filters: { status: PENDING_AUTO_REVIEW }
+            limit: 1000
+            orderBy: ID
+            workflowIds: $workflowIds
+        ) {
+            submissions {
+                id
+            }
+        }
+    }
+    """
+
+    def __init__(self, workflow_id: int):
+        super().__init__(self.QUERY, {"workflowIds": [workflow_id]})
+
+    def process_response(self, response: Any) -> set[int]:
+        response = super().process_response(response)
+        return {
+            submission["id"] for submission in response["submissions"]["submissions"]
+        }
+
+
+class SubmissionIdsPendingDownstream(GraphQLRequest):  # type: ignore[misc]
+    QUERY = """
+    query SubmissionIdsPendingDownstream($workflowIds: [Int]) {
+        submissions(
+            desc: false
+            filters: {
+                AND: {
+                    retrieved: false
+                    OR: [
+                        { status: COMPLETE }
+                        { status: FAILED }
+                    ]
+                }
+            }
+            limit: 1000
+            orderBy: ID
+            workflowIds: $workflowIds
+        ) {
+            submissions {
+                id
+            }
+        }
+    }
+    """
+
+    def __init__(self, workflow_id: int):
+        super().__init__(self.QUERY, {"workflowIds": [workflow_id]})
+
+    def process_response(self, response: Any) -> set[int]:
+        response = super().process_response(response)
+        return {
+            submission["id"] for submission in response["submissions"]["submissions"]
+        }

--- a/indico_toolkit/polling/queries.py
+++ b/indico_toolkit/polling/queries.py
@@ -1,6 +1,9 @@
-from typing import Any
+from typing import TYPE_CHECKING
 
 from indico.queries import GraphQLRequest  # type: ignore[import-untyped]
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
 class SubmissionIdsPendingAutoReview(GraphQLRequest):  # type: ignore[misc]
@@ -23,7 +26,7 @@ class SubmissionIdsPendingAutoReview(GraphQLRequest):  # type: ignore[misc]
     def __init__(self, workflow_id: int):
         super().__init__(self.QUERY, {"workflowIds": [workflow_id]})
 
-    def process_response(self, response: Any) -> set[int]:
+    def process_response(self, response: "Any") -> set[int]:
         response = super().process_response(response)
         return {
             submission["id"] for submission in response["submissions"]["submissions"]
@@ -58,7 +61,7 @@ class SubmissionIdsPendingDownstream(GraphQLRequest):  # type: ignore[misc]
     def __init__(self, workflow_id: int):
         super().__init__(self.QUERY, {"workflowIds": [workflow_id]})
 
-    def process_response(self, response: Any) -> set[int]:
+    def process_response(self, response: "Any") -> set[int]:
         response = super().process_response(response)
         return {
             submission["id"] for submission in response["submissions"]["submissions"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ home-page = "https://github.com/IndicoDataSolutions/Indico-Solutions-Toolkit"
 classifiers = [ "License :: OSI Approved :: MIT License",]
 description-file = "README.md"
 requires = [
-    "indico-client>=5.1.4",
+    "indico-client>=6.1.0",
     "plotly==5.2.1",
     "tqdm==4.50.0",
     "faker==13.3.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-indico-client>=5.1.4
+indico-client>=6.1.0
 python-dateutil==2.8.1
 pytz==2021.1
 pytest==8.3.4


### PR DESCRIPTION
This PR adds two classes that implement and encapsulate best-practices behavior for Auto Review and Downstream polling patterns. Combined with the `results` and `etloutput` modules, this factors out much of the scaffolding of an Auto Review or Downstream pod.

A project need only define one or both of these functions:

```python
async def auto_review(result: Result, etl_outputs: dict[Document, EtlOutput]) -> AutoReviewed:
    """
    Apply auto review rules to predictions and determine straight through processing.
    Any IO performed (network requests, file reads/writes, etc) must be `await`ed to
    avoid blocking the asyncio loop that runs this coroutine.
    """
    predictions = result.pre_review

    # Auto review rules here.

    return AutoReviewed(
        changes=predictions.to_changes(result),
        stp=True,  # Defaults to `False` and may be omitted.
    )
```

```python
async def downstream(submission: Submission) -> None:
    """
    Send a submission downstream.
    """
    await httpx.post(
        "https://dowstream_endpoint",
        json={
            "id": submission.id,
            "status": submission.status,
            "output_url": submission.result_file,
        },
    )
```

And instantiate one or both of the polling classes in a package's `__main__.py`, CLI, or other entrypoint:

```python
asyncio.run(AutoReviewPoller(IndicoConfig(), workflow_id, auto_review).poll_forever())
```

```python
asyncio.run(DownstreamPoller(IndicoConfig(), workflow_id, downstream).poll_forever())
```

```python
asyncio.run(
    asyncio.gather(
        AutoReviewPoller(IndicoConfig(), workflow_id, auto_review).poll_forever(),
        DownstreamPoller(IndicoConfig(), workflow_id, downstream).poll_forever(),
    )
)
```

`AutoReviewPoller` loads the result file and etl output as dataclasses, applies use-case-specific logic with the `auto_review` callback, and submits the changes with optional STP.

`DownstreamPoller` loads the submission metadata, sends it downstream with the `downstream` callback, and marks the submission retrieved.

Implemented best-practices behavior includes:

- Asyncio workers process submissions concurrently, up to a maximum number of workers configurable by the `worker_count` kwarg.
- Continuous polling for new submissions keeps the worker queue saturated, configurable by the `poll_delay` kwarg.
- Retry logic gives workers the best chance to recover from a network error, configurable by the `retry_count` kwarg and friends.
- Robust error handling and logging and ensures the poller stays alive and errors are logged when workers fail.
- Max workers, spawn rate, etl output loading, and retry behavior have sane defaults and are all configurable by kwargs.

See [examples/poll_auto_review.py](https://github.com/IndicoDataSolutions/Indico-Solutions-Toolkit/blob/db6081f2daf31276121e388e064e0996c0575083/examples/poll_auto_review.py) and the class definitions for [AutoReviewPoller](https://github.com/IndicoDataSolutions/Indico-Solutions-Toolkit/blob/db6081f2daf31276121e388e064e0996c0575083/indico_toolkit/polling/autoreview.py) and [DownstreamPoller](https://github.com/IndicoDataSolutions/Indico-Solutions-Toolkit/blob/db6081f2daf31276121e388e064e0996c0575083/indico_toolkit/polling/downstream.py) for more details.