### PR TITLE
Fix Typos In Unit Tests

### DIFF
--- a/tests/etloutput/test_token_table_cell.py
+++ b/tests/etloutput/test_token_table_cell.py
@@ -43,7 +43,7 @@ def line_item_span() -> Span:
 
 
 @pytest.fixture
-def mulitple_table_span() -> Span:
+def multiple_table_span() -> Span:
     return Span(page=1, start=1217, end=1299)
 
 
@@ -107,8 +107,8 @@ def test_table_cells(etl_output: EtlOutput, line_item_span: Span) -> None:
         assert cell == correct_cell
 
 
-def test_multiple_tables(etl_output: EtlOutput, mulitple_table_span: Span) -> None:
-    table_cells = etl_output.table_cells_for(mulitple_table_span)
+def test_multiple_tables(etl_output: EtlOutput, multiple_table_span: Span) -> None:
+    table_cells = etl_output.table_cells_for(multiple_table_span)
     cells = [cell for (table, cell) in table_cells]
     _correct_cells = etl_output.tables[2].rows[-1] + etl_output.tables[3].rows[0]
     correct_cells = [cell for cell in _correct_cells if cell.text]

--- a/tests/etloutput/test_token_table_cell.py
+++ b/tests/etloutput/test_token_table_cell.py
@@ -39,7 +39,7 @@ def content_span() -> Span:
 
 @pytest.fixture
 def line_item_span() -> Span:
-    return Span(page=1, start=1311, end=1244)
+    return Span(page=1, start=1311, end=1344)
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR fixes a couple typos in the unit test suite I found while checking the feature parity of the C# version. These don't change any test results or require publishing a new version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only typo fixes (span end index and fixture naming) with no production code changes.
> 
> **Overview**
> Fixes typos in `tests/etloutput/test_token_table_cell.py` by correcting the `line_item_span` end offset and renaming the misspelled `mulitple_table_span` fixture (and its usage) to `multiple_table_span`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9ce69b91d2e7abcbf4f03201137f9d442b64cb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->